### PR TITLE
Hotfix/fix branch name in ci pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,6 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
-        with:
-          ref: lt/ci
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,4 @@ jobs:
           render: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+           


### PR DESCRIPTION
Originally added the CI configuration to point to the branch I was testing the CI with. Forgot to remove that configuration when I merged the branch, now that it doesn't exist anymore the CI pipeline is failing :(